### PR TITLE
Fix exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-EXPOSE 9876
+EXPOSE 9877
 COPY fastcom-exporter*.apk /tmp
 RUN apk add --allow-untrusted /tmp/fastcom-exporter*.apk
 ENTRYPOINT ["/usr/local/bin/fastcom-exporter"]


### PR DESCRIPTION
Hey, this is a great exporter, thanks for building it.

I've been using both `fastcom-exporter` with `speedtest-exporter`, but I've noticed them both expose port `9876`, even though throughout the fastcom [doc](https://github.com/caarlos0/fastcom-exporter/blob/main/README.md?plain=1#L16) and [server](https://github.com/caarlos0/fastcom-exporter/blob/main/main.go#L19) you expose port `9877`.

I'm not entirely sure why Prometheus keeps working with both instances if they expose the same port though. 🤔 